### PR TITLE
Add minimal Python package with round-trip test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,8 @@ build/
 .vscode/
 
 ### Mac OS ###
-.DS_Store
+\.DS_Store
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@
 * hwp파일을 hwpx파일로 변환하는 라이브러리는 https://github.com/neolord0/hwp2hwpx 을 참조해 주세요.
 * hwpxlib의 확장 라이브러리는 https://github.com/neolord0/hwpxlib_ext 을 참조해 주세요.
 
+## Python usage
+
+간단한 Python 모듈을 포함하여 Java 라이브러리의 `Reader` 와 `Writer` 기능을 흉내냅니다.
+
+```java
+HwpxReader reader = new HwpxReader();
+HwpxFile file = reader.read("input.hwpx");
+
+HwpxWriter writer = new HwpxWriter();
+writer.write(file, "output.hwpx");
+```
+
+```python
+from hwpxlib import HwpxArchive
+
+archive = HwpxArchive.read("input.hwpx")
+archive.write("output.hwpx")
+```
+
 2025.05.23
 =========================================================================================
 * pull request #21 : TrackChageConfig에 configItemSet 객체 추가..

--- a/hwpxlib/__init__.py
+++ b/hwpxlib/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal Python interface for reading and writing ``.hwpx`` files."""
+
+from .archive import HwpxArchive, read_hwpx, write_hwpx
+
+__all__ = ["HwpxArchive", "read_hwpx", "write_hwpx"]

--- a/hwpxlib/archive.py
+++ b/hwpxlib/archive.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+from zipfile import ZipFile
+
+
+@dataclass
+class HwpxArchive:
+    """Representation of an ``.hwpx`` archive.
+
+    The archive is stored as a mapping of file names to their byte contents.
+    """
+
+    files: Dict[str, bytes]
+
+    @classmethod
+    def read(cls, path: str) -> "HwpxArchive":
+        """Read a ``.hwpx`` file and return an :class:`HwpxArchive`."""
+        with ZipFile(path, "r") as zf:
+            files = {name: zf.read(name) for name in zf.namelist()}
+        return cls(files)
+
+    def write(self, path: str) -> None:
+        """Write the archive to ``path``."""
+        with ZipFile(path, "w") as zf:
+            for name, data in self.files.items():
+                zf.writestr(name, data)
+
+
+def read_hwpx(path: str) -> HwpxArchive:
+    """Convenience function to read a ``.hwpx`` archive."""
+    return HwpxArchive.read(path)
+
+
+def write_hwpx(archive: HwpxArchive, path: str) -> None:
+    """Convenience function to write a :class:`HwpxArchive` to disk."""
+    archive.write(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hwpxlib"
+version = "0.1.0"
+description = "Minimal Python interface for reading and writing hwpx files"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Unknown"}]
+license = {file = "license.txt"}
+
+[tool.setuptools.packages.find]
+include = ["hwpxlib*"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,0 +1,11 @@
+from hwpxlib import HwpxArchive
+
+
+def test_read_write_roundtrip(tmp_path):
+    original = HwpxArchive.read("testFile/tool/blank.hwpx")
+    out_path = tmp_path / "copy.hwpx"
+    original.write(out_path)
+    reread = HwpxArchive.read(out_path)
+    assert original.files.keys() == reread.files.keys()
+    for key in original.files:
+        assert original.files[key] == reread.files[key]


### PR DESCRIPTION
## Summary
- add pyproject configuration for a simple `hwpxlib` python package
- implement `HwpxArchive` with read/write helpers
- exercise round-trip archive operations in a pytest
- document python usage alongside existing Java examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68949b6240d883329f85ad276ba2fa6a