### PR TITLE
Add reader and writer tests

### DIFF
--- a/hwpxlib/__init__.py
+++ b/hwpxlib/__init__.py
@@ -1,5 +1,8 @@
 
 
+"""Public package interface for :mod:`hwpxlib`."""
+
+from .archive import HwpxArchive, read_hwpx, write_hwpx
 from .hwpxfile import (
     HWPXFile,
     Version,
@@ -15,15 +18,18 @@ from .hwpxfile import (
 )
 
 __all__ = [
-    'HWPXFile',
-    'Version',
-    'Manifest',
-    'Container',
-    'Content',
-    'Header',
-    'MasterPages',
-    'Sections',
-    'Settings',
-    'History',
-    'Charts',
+    "HwpxArchive",
+    "read_hwpx",
+    "write_hwpx",
+    "HWPXFile",
+    "Version",
+    "Manifest",
+    "Container",
+    "Content",
+    "Header",
+    "MasterPages",
+    "Sections",
+    "Settings",
+    "History",
+    "Charts",
 ]

--- a/tests/test_reader_writer.py
+++ b/tests/test_reader_writer.py
@@ -1,0 +1,35 @@
+from xml.etree import ElementTree as ET
+
+from reader import HWPXReader, MIMETYPE
+from writer import HwpxWriter
+
+
+def test_reader_parses_sample():
+    hwpx = HWPXReader.read("testFile/tool/blank.hwpx")
+    assert hwpx.version_xml is not None
+    assert hwpx.content_hpf is not None
+    assert "Contents/section0.xml" in hwpx.content_files
+
+
+def test_writer_roundtrip(tmp_path):
+    hwpx = HWPXReader.read("testFile/tool/blank.hwpx")
+    version_xml = ET.tostring(hwpx.version_xml.getroot(), encoding="unicode")
+    container_xml = ET.tostring(hwpx.container_xml.getroot(), encoding="unicode")
+    manifest_xml = ET.tostring(hwpx.manifest_xml.getroot(), encoding="unicode")
+    content_hpf = ET.tostring(hwpx.content_hpf.getroot(), encoding="unicode")
+    files = {
+        name: ET.tostring(tree.getroot(), encoding="unicode")
+        for name, tree in hwpx.content_files.items()
+    }
+    writer = HwpxWriter(
+        version_xml,
+        container_xml,
+        manifest_xml,
+        content_hpf,
+        files,
+        MIMETYPE,
+    )
+    out_path = tmp_path / "out.hwpx"
+    writer.write(out_path)
+    reread = HWPXReader.read(out_path)
+    assert set(reread.content_files.keys()) == set(hwpx.content_files.keys())


### PR DESCRIPTION
## Summary
- Expose HwpxArchive and helpers in the package’s public API
- Add unit tests for reading a sample HWPX file and writer round‑trip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689496f9a00c833299d33bbe849523c4