### PR TITLE
Handle errors reading original hwpx compression info

### DIFF
--- a/text_modifier.py
+++ b/text_modifier.py
@@ -7,6 +7,7 @@ reader와 text_extractor 모듈을 조합하여 사용합니다.
 from typing import Callable, Dict, Any
 import xml.etree.ElementTree as ET
 import re
+import logging
 
 from reader import HWPXReader, MIMETYPE
 from text_extractor import extract_text
@@ -182,8 +183,8 @@ def _save_modified_hwpx(hwpx, output_path: str, original_path: str = None) -> No
             with zipfile.ZipFile(original_path, 'r') as orig_zf:
                 for info in orig_zf.infolist():
                     compression_info[info.filename] = info.compress_type
-        except:
-            pass
+        except Exception as e:
+            logging.warning("원본 HWPX 압축 정보를 읽는 중 오류 발생: %s", e)
     
     with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         # Store mimetype uncompressed as first entry.


### PR DESCRIPTION
## Summary
- add logging dependency to support error reporting
- warn instead of silently passing when original HWPX compression info can't be read

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c4a4a1f48332bd6154dfc34ad7a0