### PR TITLE
Add export_text_segments utility

### DIFF
--- a/tests/test_export_segments.py
+++ b/tests/test_export_segments.py
@@ -1,0 +1,16 @@
+import json
+
+from text_modifier import export_text_segments
+
+
+def test_export_segments(tmp_path):
+    out_json = tmp_path / "segments.json"
+    export_text_segments("sample.hwpx", out_json)
+
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert data, "expected at least one text segment"
+
+    first = data[0]
+    assert {"index", "file", "attr", "text", "format"} <= set(first.keys())
+    assert isinstance(first["format"], dict)


### PR DESCRIPTION
## Summary
- add `enumerate_text_nodes` and `export_text_segments` to dump text with formatting to JSON
- expose `export` CLI command in `text_modifier.py`
- test text segment export

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896d48c87748332984dcfc908ea1eb9