### PR TITLE
Add selective text replacement utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ archive = HwpxArchive.read("input.hwpx")
 archive.write("output.hwpx")
 ```
 
+### Selective text replacement
+
+텍스트를 문장 단위로 교체하려면 `text_modifier` 모듈의 도우미 함수를 사용할 수 있습니다.
+
+```python
+from text_modifier import list_sentences, modify_selected_text
+
+# 문장 목록을 JSON으로 확인 (phrase_id 포함)
+list_sentences("input.hwpx", as_json=True)
+
+# 예시 출력
+# [
+#   {"index": 0, "phrase_id": "2764991984", "text": "첫 번째 문장입니다."},
+#   {"index": 1, "phrase_id": "2764991984", "text": "두 번째 문장입니다."}
+# ]
+
+# 특정 인덱스만 교체
+replacements = {
+    1: "두 번째 문장을 새로운 내용으로 교체합니다.",
+    # ("section0.xml", 5): lambda s: s.upper(),  # 파일 이름과 인덱스로 지정도 가능
+}
+
+modify_selected_text("input.hwpx", "output.hwpx", replacements)
+```
+
 ## Development notes
 
 - The helper functions `_modify_text_preserve_formatting` and `_modify_text_simple`

--- a/tests/test_modify_selected_text.py
+++ b/tests/test_modify_selected_text.py
@@ -1,0 +1,23 @@
+from text_modifier import enumerate_text_nodes, modify_selected_text
+from reader import HWPXReader
+
+
+def test_modify_selected_text(tmp_path):
+    src = "testFile/tool/textextractor/multipara.hwpx"
+
+    hwpx = HWPXReader.read(src)
+    nodes = list(enumerate_text_nodes(hwpx))
+    assert len(nodes) >= 2
+
+    # pick a node with alphabetic characters to ensure modification
+    target_index = 7
+    out = tmp_path / "out.hwpx"
+    count = modify_selected_text(src, out, {target_index: "REPLACED"})
+    assert count == 1
+
+    hwpx_out = HWPXReader.read(out)
+    nodes_out = list(enumerate_text_nodes(hwpx_out))
+
+    assert nodes_out[target_index][4] == "REPLACED"
+    # Another index should stay the same
+    assert nodes_out[0][4] == nodes[0][4]

--- a/tests/test_phrase_id_json.py
+++ b/tests/test_phrase_id_json.py
@@ -1,0 +1,20 @@
+import json
+
+from text_modifier import enumerate_text_nodes, list_sentences
+from reader import HWPXReader
+
+
+def test_phrase_id_grouping():
+    hwpx = HWPXReader.read("testFile/tool/textextractor/RectInPara.hwpx")
+    by_pid = {}
+    for idx, _file, _elem, _attr, text, pid in enumerate_text_nodes(hwpx):
+        by_pid.setdefault(pid, []).append(text)
+    counts = [len(v) for pid, v in by_pid.items() if pid is not None]
+    assert max(counts) >= 5
+
+
+def test_list_sentences_json_includes_phrase_id(capsys):
+    list_sentences("testFile/tool/textextractor/RectInPara.hwpx", as_json=True)
+    output = capsys.readouterr().out
+    data = json.loads(output)
+    assert all("phrase_id" in item for item in data)

--- a/text_modifier.py
+++ b/text_modifier.py
@@ -4,9 +4,24 @@
 가능하다면 :mod:`compatible_writer` 의 저장 함수를 사용하고, 그렇지 않으면 ZIP 기반
 로직으로 직접 저장하여 네임스페이스를 보존합니다. `reader` 와
 `text_extractor` 모듈을 조합하여 사용합니다.
+
+추가로, 문서의 모든 텍스트 노드를 순회하여 인덱스와 함께 열거하거나, 특정
+인덱스의 텍스트만 선택적으로 교체하는 고급 기능을 제공합니다. 이는 문장 단위의
+세밀한 수정 작업을 수행할 때 유용합니다.
+
+사용 예::
+
+    from text_modifier import list_sentences, modify_selected_text
+
+    list_sentences("input.hwpx", as_json=True)  # 문장 목록을 JSON으로 확인
+
+    replacements = {
+        3: "세 번째 문장을 새로 작성합니다.",
+    }
+    modify_selected_text("input.hwpx", "output.hwpx", replacements)
 """
 
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Iterable, Tuple, Union, Optional
 import re
 
 from reader import HWPXReader
@@ -14,6 +29,42 @@ from text_extractor import extract_text
 from writer import save_modified_hwpx
 
 HP_NAMESPACE = "{http://www.hancom.co.kr/hwpml/2011/paragraph}"
+
+
+def enumerate_text_nodes(hwpx) -> Iterable[Tuple[int, str, Any, str, str, Optional[str]]]:
+    """Yield all text nodes from ``hwpx`` in reading order.
+
+    Parameters
+    ----------
+    hwpx:
+        :class:`reader.HWPXFile` 객체. ``HWPXReader.read`` 로 획득한다.
+
+    Yields
+    ------
+    ``(index, file_name, element, attr_name, text, phrase_id)`` 튜플
+        ``element`` 는 :mod:`xml.etree.ElementTree` 의 요소이며, ``attr_name`` 은
+        ``"text"`` 또는 ``"tail"`` 이다. ``index`` 는 문서 전반에서의 순번이며
+        ``phrase_id`` 는 상위 ``hp:p`` 요소의 ``id`` 속성 값이다.
+    """
+
+    idx = 0
+
+    def walk(elem, file_name: str, current_pid: Optional[str]):
+        nonlocal idx
+        if elem.tag == HP_NAMESPACE + "p":
+            current_pid = elem.attrib.get("id")
+        if elem.text is not None:
+            yield idx, file_name, elem, "text", elem.text, current_pid
+            idx += 1
+        for child in list(elem):
+            yield from walk(child, file_name, current_pid)
+        if elem.tail is not None:
+            yield idx, file_name, elem, "tail", elem.tail, current_pid
+            idx += 1
+
+    for file_name, tree in hwpx.content_files.items():
+        root = tree.getroot()
+        yield from walk(root, file_name, None)
 
 # Note: helper functions `_modify_text_preserve_formatting` and
 # `_modify_text_simple` were removed. If future features require them,
@@ -56,6 +107,50 @@ def modify_hwpx_text(input_path: str, output_path: str, modifier_func) -> None:
             hwpx.modified_files.add(name)
     
     _save_modified_hwpx(hwpx, output_path, input_path)
+
+
+def modify_selected_text(
+    input_path: str,
+    output_path: str,
+    replacements: Dict[Union[int, Tuple[str, int]], Union[str, Callable[[str], str]]],
+) -> int:
+    """선택된 인덱스의 텍스트만 교체합니다.
+
+    ``replacements`` 딕셔너리는 전역 인덱스 ``int`` 또는 ``(file_name, index)``
+    튜플을 키로 사용하며, 값으로는 교체할 문자열 또는 콜백 함수를 지정합니다.
+    콜백 함수는 기존 문자열을 인자로 받아 새 문자열을 반환해야 합니다.
+
+    Returns
+    -------
+    int
+        실제로 변경된 텍스트 노드 수
+    """
+
+    hwpx = HWPXReader.read(input_path)
+
+    if not hasattr(hwpx, "modified_files"):
+        hwpx.modified_files = set()
+
+    modified_count = 0
+
+    for idx, file_name, elem, attr, text, _pid in enumerate_text_nodes(hwpx):
+        key = (file_name, idx)
+        repl = None
+        if key in replacements:
+            repl = replacements[key]
+        elif idx in replacements:
+            repl = replacements[idx]
+        if repl is None:
+            continue
+
+        new_text = repl(text) if callable(repl) else repl
+        if new_text != text:
+            setattr(elem, attr, new_text)
+            hwpx.modified_files.add(file_name)
+            modified_count += 1
+
+    _save_modified_hwpx(hwpx, output_path, input_path)
+    return modified_count
 
 
 def replace_text_in_hwpx(
@@ -141,45 +236,77 @@ def remove_extra_spaces(input_path: str, output_path: str) -> None:
     """HWPX 파일에서 연속된 공백을 하나로 줄입니다."""
     def space_reducer(text: str) -> str:
         return re.sub(r'\s+', ' ', text).strip()
-    
+
     modify_hwpx_text(input_path, output_path, space_reducer)
+
+
+def list_sentences(file_path: str, as_json: bool = False) -> None:
+    """문서의 모든 문장을 인덱스와 함께 출력하거나 JSON으로 내보냅니다."""
+
+    hwpx = HWPXReader.read(file_path)
+    entries = [
+        {
+            "index": idx,
+            "file_name": _file,
+            "text": text,
+            "phrase_id": pid,
+        }
+        for idx, _file, _elem, _attr, text, pid in enumerate_text_nodes(hwpx)
+    ]
+
+    if as_json:
+        import json
+
+        print(json.dumps(entries, ensure_ascii=False, indent=2))
+    else:
+        for item in entries:
+            print(f"{item['index']}: {item['text']}")
 
 
 if __name__ == "__main__":
     import sys
-    
-    if len(sys.argv) < 3:
+
+    if len(sys.argv) < 2:
         print("Usage:")
+        print("  python text_modifier.py list <input.hwpx> [--json]")
+        print("  python text_modifier.py stats <input.hwpx>")
         print("  python text_modifier.py replace <input.hwpx> <output.hwpx> <search> <replace>")
         print("  python text_modifier.py upper <input.hwpx> <output.hwpx>")
         print("  python text_modifier.py lower <input.hwpx> <output.hwpx>")
-        print("  python text_modifier.py stats <input.hwpx>")
     else:
         command = sys.argv[1]
-        input_file = sys.argv[2]
-        
-        if command == "stats":
+
+        if command == "list" and len(sys.argv) >= 3:
+            as_json = len(sys.argv) >= 4 and sys.argv[3] == "--json"
+            list_sentences(sys.argv[2], as_json=as_json)
+
+        elif command == "stats" and len(sys.argv) >= 3:
+            input_file = sys.argv[2]
             stats = get_hwpx_text_stats(input_file)
             print("HWPX 파일 텍스트 통계:")
             for key, value in stats.items():
                 print(f"  {key}: {value:,}")
-        
+
         elif len(sys.argv) >= 4:
+            input_file = sys.argv[2]
             output_file = sys.argv[3]
-            
+
             if command == "replace" and len(sys.argv) >= 6:
                 search_text = sys.argv[4]
                 replace_text = sys.argv[5]
                 count = replace_text_in_hwpx(input_file, output_file, search_text, replace_text)
                 print(f"텍스트 교체 완료: {count}개 교체됨")
-            
+
             elif command == "upper":
                 uppercase_hwpx_text(input_file, output_file)
                 print("대문자 변환 완료")
-            
+
             elif command == "lower":
                 lowercase_hwpx_text(input_file, output_file)
                 print("소문자 변환 완료")
-            
+
             else:
                 print("알 수 없는 명령어입니다.")
+
+        else:
+            print("알 수 없는 명령어입니다.")


### PR DESCRIPTION
## Summary
- enumerate text nodes with paragraph `phrase_id` to group related runs
- allow `list_sentences` to emit JSON with phrase IDs and add CLI `--json` option
- document phrase-aware JSON export and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ce8adf44833281e8f817ec20238c