### PR TITLE
Add paragraph IDs to exported text segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,33 @@ archive = HwpxArchive.read("input.hwpx")
 archive.write("output.hwpx")
 ```
 
+## Exporting and applying text segments
+
+`text_modifier.export_text_segments` can serialize every text run in a
+`*.hwpx` file into a JSON array. Each element describes a single run and
+includes a `phrase_id` field capturing the `id` of the surrounding
+`<hp:p>` element. Runs originating from the same paragraph therefore share
+the same `phrase_id`, allowing consumers to group them into phrases.
+
+```json
+[
+  {
+    "index": 0,
+    "file": "Contents/section0.xml",
+    "attr": "text",
+    "text": "Hello",
+    "phrase_id": "0",
+    "format": {
+      "elem": {}
+    }
+  }
+]
+```
+
+The companion `apply_segments` function ignores unrecognized keys like
+`phrase_id`. This means the JSON above can be modified (e.g., adjust the
+`text` field) and written back without removing the additional metadata.
+
 ## Development notes
 
 - The helper functions `_modify_text_preserve_formatting` and `_modify_text_simple`

--- a/tests/test_apply_segments.py
+++ b/tests/test_apply_segments.py
@@ -23,3 +23,4 @@ def test_apply_segments(tmp_path):
         seg for seg in updated_segments if seg["file"] == target["file"] and seg["index"] == target["index"]
     )
     assert updated["text"] == "MODIFIED TEXT"
+    assert updated["phrase_id"] == target["phrase_id"]

--- a/tests/test_export_segments.py
+++ b/tests/test_export_segments.py
@@ -12,5 +12,24 @@ def test_export_segments(tmp_path):
     assert data, "expected at least one text segment"
 
     first = data[0]
-    assert {"index", "file", "attr", "text", "format"} <= set(first.keys())
+    assert {"index", "file", "attr", "text", "format", "phrase_id"} <= set(first.keys())
     assert isinstance(first["format"], dict)
+
+
+def test_phrase_id_groups_runs(tmp_path):
+    out_json = tmp_path / "segments.json"
+    export_text_segments("sample.hwpx", out_json)
+
+    data = json.loads(out_json.read_text(encoding="utf-8"))
+
+    groups = {}
+    for seg in data:
+        if seg.get("phrase_id") is None or "paragraph" not in seg["format"]:
+            continue
+        key = (seg["phrase_id"], json.dumps(seg["format"]["paragraph"], sort_keys=True))
+        groups.setdefault(key, []).append(seg)
+
+    multi_segments = next((g for g in groups.values() if len(g) >= 2), None)
+    assert multi_segments is not None, "expected at least one paragraph with multiple segments"
+    pid = multi_segments[0]["phrase_id"]
+    assert all(seg["phrase_id"] == pid for seg in multi_segments)


### PR DESCRIPTION
## Summary
- capture parent `<hp:p>` IDs when exporting text segments and expose them as `phrase_id`
- document `phrase_id` usage and sample JSON, clarifying that `apply_segments` ignores unknown fields
- test grouping of segments by paragraph and preserve `phrase_id` through apply/export roundtrips

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68973c8462f883329a43ea4e882b1e79